### PR TITLE
Fix power prior weights

### DIFF
--- a/R/post.R
+++ b/R/post.R
@@ -106,9 +106,11 @@ calc_post_norm<- function(
     }
 
   } else {
-    if(prior_fam == "student_t") {
+    if(prior_fam == "normal"){
+      out_dist <- calc_t_post(prior, nIC, pull(data, !!response))
+    } else if(prior_fam == "student_t") {
       out_dist <- t_to_mixnorm(prior) |>
-        calc_t_post(nIC, pull(data, !!response))
+      calc_t_post(nIC, pull(data, !!response))
     } else if(prior_fam == "mixture") {
       out_dist <- mix_t_to_mix(prior) |>
         calc_t_post(nIC, pull(data, !!response))

--- a/R/pwr_prior.R
+++ b/R/pwr_prior.R
@@ -61,7 +61,7 @@ calc_power_prior_beta <- function(external_data, response, prior){
     weights <- data$`___weight___`
   } else if(is.data.frame(external_data)){
     data <- external_data
-    weights <- 1
+    weights <- rep(1, nrow(data))
   } else {
     cli_abort("{.agr external_data} either a dataset or `prop_scr` object type")
   }
@@ -173,7 +173,7 @@ calc_power_prior_norm <- function(external_data, response, prior = NULL, externa
     weights <- data$`___weight___`
   } else if(is.data.frame(external_data)){
     data <- external_data
-    weights <- 1
+    weights <- rep(1, nrow(data))
   } else {
     cli_abort("{.agr external_data} either a dataset or `prop_scr` object type")
   }
@@ -327,7 +327,7 @@ calc_power_prior_weibull <- function(external_data,
     weights <- data$`___weight___`
   } else if(is.data.frame(external_data)){
     data <- external_data
-    weights <- 1
+    weights <- rep(1, nrow(data))
   } else {
     cli_abort("{.agr external_data} either a dataset or `prop_scr` object type")
   }

--- a/tests/testthat/test-calc_power_prior_norm.R
+++ b/tests/testthat/test-calc_power_prior_norm.R
@@ -29,8 +29,10 @@ test_that("pwr_prior_norm_result returns the correct value", {
                                                  response = y,
                                                  prior = initial_prior,
                                                  external_sd = sd_external_control)
-  expect_equal(round(parameters(pwr_prior_norm_result)$mu, digits=3), 801.025)
-  expect_equal(round(parameters(pwr_prior_norm_result)$sigma, digits=6), 0.149983)
+  expect_equal(parameters(pwr_prior_norm_result)$mu, 8.012034,
+               tolerance = 0.01)
+  expect_equal(parameters(pwr_prior_norm_result)$sigma, 0.01499998,
+               tolerance = 0.001)
   expect_equal(family(pwr_prior_norm_result), "normal")
 })
 

--- a/vignettes/continuous.Rmd
+++ b/vignettes/continuous.Rmd
@@ -114,7 +114,7 @@ As an alternative to using `robustify_norm`, we can instead use the `dist_mixtur
 
 ```{r}
 n_external <- nrow(ex_norm_df)
-mix_prior <- robustify_norm(pwr_prior, n_external)
+mix_prior <- robustify_norm(pwr_prior, n_external, weights = c(0.5, 0.5))
 plot_dist("Power Prior" = pwr_prior,
           "Vague Prior" = dist_normal(mean = mix_means(mix_prior)["vague"],
                                       sd = mix_sigmas(mix_prior)["vague"]),

--- a/vignettes/tte.Rmd
+++ b/vignettes/tte.Rmd
@@ -122,7 +122,7 @@ We can print the mean vectors and covariance matrices of each MVN component usin
 
 ```{r}
 r_external <- sum(ex_tte_df$event)   # number of observed events
-mix_prior <- robustify_mvnorm(pwr_prior, r_external)   # RMP
+mix_prior <- robustify_mvnorm(pwr_prior, r_external, weights = c(0.5, 0.5))   # RMP
 mix_means(mix_prior)     # mean vectors
 mix_sigmas(mix_prior)    # mean covariance matrices
 #plot_dist(mix_prior)


### PR DESCRIPTION
The following changes were made:

- For all three calc_power_prior_... functions, I changed the weights from 1 to a vector of 1s for cases when external data are read in directly rather instead of a prop_scr_obj
- In calc_post_norm, I added if statement to allow for a normal prior to be read in for the case with SD unknown (please verify this if statement is correct)
- I updated the normal and TTE vignettes so that the robustify_[mv]norm functions include the weights statement